### PR TITLE
add api upload image

### DIFF
--- a/src/modules/topic/dto/file-upload.dto.ts
+++ b/src/modules/topic/dto/file-upload.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+
+export class FileUploadDto {
+  @ApiProperty({
+    type: 'string',
+    format: 'binary',
+    description: 'File hình ảnh cần tải lên',
+  })
+  image: any;
+}

--- a/src/modules/topic/topic.controller.ts
+++ b/src/modules/topic/topic.controller.ts
@@ -1,66 +1,76 @@
-import { 
-  Body, 
-  Controller, 
-  Delete, 
-  Get, 
-  HttpException, 
-  HttpStatus, 
-  Param, 
-  Post, 
-  Put, 
-  UploadedFile, 
-  UseGuards, 
-  UseInterceptors 
+import {
+  Body,
+  Controller,
+  Delete,
+  Get,
+  HttpException,
+  HttpStatus,
+  Param,
+  Post,
+  Put,
+  UploadedFile,
+  UseGuards,
+  UseInterceptors,
 } from '@nestjs/common';
-import { TopicsService } from './topic.service';
-import { CreateTopicDto } from './dto/create-topic.dto';
-import { UpdateTopicDto } from './dto/update-topic.dto';
+
 import { FileInterceptor } from '@nestjs/platform-express';
 import { IFile } from 'src/interfaces/file.interface';
-import { AwsS3Service } from 'src/services/aws-s3.service';
-import { Roles } from 'src/decorators/roles.decorator';
-;
-import { JwtAccessTokenGuard } from '@modules/auth/guards/jwt-access-token.guard';
 
+import { JwtAccessTokenGuard } from '@modules/auth/guards/jwt-access-token.guard';
 import { Public } from 'src/decorators/auth.decorator';
+import { TopicsService } from '@modules/topic/topic.service';
+import { CreateTopicDto } from '@modules/topic/dto/create-topic.dto';
+import { UpdateTopicDto } from '@modules/topic/dto/update-topic.dto';
+import { ImageUploadService } from 'src/services/image-upload.service';
+import { ApiBody, ApiConsumes } from '@nestjs/swagger';
+import { FileUploadDto } from '@modules/topic/dto/file-upload.dto';
 
 
 @Controller('topics')
 export class TopicsController {
   constructor(
     private readonly topicsService: TopicsService,
-    private readonly awsS3Service: AwsS3Service,
+    private readonly imageUploadService: ImageUploadService,
   ) {}
+
+
+  @Post('upload-image')
+  @ApiConsumes('multipart/form-data')
+  @ApiBody({
+    description: 'Image upload',
+    type: FileUploadDto,
+  })
+  @Public()
+  @UseGuards(JwtAccessTokenGuard)
+  @UseInterceptors(FileInterceptor('image'))
+  async uploadImage(@UploadedFile() image: IFile) {
+    try {
+      const uploadResult = await this.imageUploadService.uploadImage(image);
+      return {
+        statusCode: HttpStatus.OK,
+        message: 'Image uploaded successfully',
+        success: true,
+        data: uploadResult,
+      };
+    } catch (error) {
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Image upload failed',
+          success: false,
+          error: error.message,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
+  }
 
   @Post()
   @Public()
-
-	@UseGuards(JwtAccessTokenGuard)
-  @UseInterceptors(FileInterceptor('image'))
-  async uploadImage(
-    @UploadedFile() image: IFile,
-    @Body() { topic_name, description }: CreateTopicDto,
-  ) {
+  @UseGuards(JwtAccessTokenGuard)
+  async create(@Body() { topic_name, description, image }: CreateTopicDto) {
     try {
-      if (!image) {
-        throw new HttpException(
-          {
-            statusCode: HttpStatus.BAD_REQUEST,
-            message: 'File is required',
-            success: false,
-          },
-          HttpStatus.BAD_REQUEST,
-        );
-      }
-
-      const uploadResult = await this.awsS3Service.uploadImage(image);
-
-      const createTopicDto: CreateTopicDto = {
-        topic_name,
-        description,
-        image: uploadResult,
-      };
-
+      const createTopicDto: CreateTopicDto = { topic_name, description, image };
       const createdTopic = await this.topicsService.create(createTopicDto);
 
       return {
@@ -82,36 +92,57 @@ export class TopicsController {
     }
   }
 
+
   @Put(':id')
   @Public()
-  
-	@UseGuards(JwtAccessTokenGuard)
-  async update(@Param('id') id: string, @Body() updateDto: UpdateTopicDto) {
-    return this.topicsService.update(id, updateDto);
+  @UseGuards(JwtAccessTokenGuard)
+  async update(
+    @Param('id') id: string,
+    @Body() { topic_name, description, image }: UpdateTopicDto,
+  ) {
+    try {
+      const updateDto: UpdateTopicDto = { topic_name, description, image };
+      const updatedTopic = await this.topicsService.update(id, updateDto);
+
+      return {
+        statusCode: HttpStatus.OK,
+        message: 'Topic updated successfully',
+        success: true,
+        data: updatedTopic,
+      };
+    } catch (error) {
+      throw new HttpException(
+        {
+          statusCode: HttpStatus.INTERNAL_SERVER_ERROR,
+          message: 'Topic update failed',
+          success: false,
+          error: error.message,
+        },
+        HttpStatus.INTERNAL_SERVER_ERROR,
+      );
+    }
   }
 
+ 
   @Delete(':id')
   @Public()
-
-	@UseGuards(JwtAccessTokenGuard)
+  @UseGuards(JwtAccessTokenGuard)
   async delete(@Param('id') id: string) {
     return this.topicsService.delete(id);
   }
 
-
+ 
   @Get()
   @Public()
-
-	@UseGuards(JwtAccessTokenGuard)
+  @UseGuards(JwtAccessTokenGuard)
   async findAll() {
     return this.topicsService.findAll();
   }
 
-  @Get(':id')
-  @Get()
-  @Public()
 
-	@UseGuards(JwtAccessTokenGuard)
+  @Get(':id')
+  @Public()
+  @UseGuards(JwtAccessTokenGuard)
   async findOne(@Param('id') id: string) {
     return this.topicsService.findOne(id);
   }

--- a/src/modules/topic/topic.module.ts
+++ b/src/modules/topic/topic.module.ts
@@ -6,6 +6,7 @@ import { Topic, TopicSchemaFactory } from './entities/topic.entity';
 import { TopicsRepository } from 'src/repositories/topic.repository';
 import { AwsS3Service } from 'src/services/aws-s3.service';
 import { GeneratorService } from 'src/services/generator.service';
+import { ImageUploadService } from 'src/services/image-upload.service';
 
 
 
@@ -24,7 +25,7 @@ import { GeneratorService } from 'src/services/generator.service';
     TopicsService,
     AwsS3Service,
     GeneratorService,
-
+    ImageUploadService,
     { provide: 'TopicsRepositoryInterface', useClass: TopicsRepository },
   ],
   exports: [TopicsService],

--- a/src/services/image-upload.service.ts
+++ b/src/services/image-upload.service.ts
@@ -1,0 +1,15 @@
+import { Injectable } from '@nestjs/common';
+import { AwsS3Service } from 'src/services/aws-s3.service';
+import { IFile } from 'src/interfaces/file.interface';
+
+@Injectable()
+export class ImageUploadService {
+  constructor(private readonly awsS3Service: AwsS3Service) {}
+
+  async uploadImage(image: IFile): Promise<string> {
+    if (!image) {
+      throw new Error('File is required');
+    }
+    return this.awsS3Service.uploadImage(image);
+  }
+}


### PR DESCRIPTION
A new API endpoint to handle image uploads. The endpoint is designed to accept image files, process them, and store them using AWS S3.

Key Features:
Endpoint: POST /topic/upload-image
Functionality:
Accepts image files like .png, .jpg,... .
Validates file type and size.
Uploads the image to AWS S3.
Returns the URL of the uploaded image.
